### PR TITLE
Update animals table

### DIFF
--- a/data.sql
+++ b/data.sql
@@ -5,3 +5,12 @@ VALUES ('Agumon', '2020-02-03', 10.23, true, 0),
 	('Gabumon', '2018-11-15', 8, true, 2),
 	('Pikachu', '2021-01-07', 15.04, false, 1),
 	('Devimon', '2017-05-12', 11, true, 5);
+
+INSERT INTO animals (name, date_of_birth, weight_kg, neutered, escape_attempts) 
+VALUES ('Charmander', '2020-02-08', -11, false, 0),
+	('Plantmon', '2021-11-15', -5.7, true, 2),
+	('Squirtle', '1993-04-02', -12.13, false, 3),
+	('Angemon', '2005-06-12', -45, true, 1),
+	('Boarmon', '2005-06-07', 20.4, true, 7),
+	('Blossom', '1998-10-13', 17, true, 3),
+	('Ditto', '2022-05-14', 22, true, 4);

--- a/queries.sql
+++ b/queries.sql
@@ -19,3 +19,8 @@ BEGIN TRANSACTION;
 UPDATE animals SET species = 'digimon' WHERE name LIKE '%mon';
 UPDATE animals SET species = 'pokemon' WHERE species = '';
 COMMIT TRANSACTION;
+
+/* Deleting all records and rolling back */
+BEGIN TRANSACTION;
+DELETE FROM animals;
+ROLLBACK TRANSACTION;

--- a/queries.sql
+++ b/queries.sql
@@ -24,3 +24,12 @@ COMMIT TRANSACTION;
 BEGIN TRANSACTION;
 DELETE FROM animals;
 ROLLBACK TRANSACTION;
+
+/* Update weight_kg */
+BEGIN TRANSACTION;
+DELETE FROM animals WHERE date_of_birth > '2022-01-01';
+SAVEPOINT first_savepoint;
+UPDATE animals SET weight_kg = weight_kg * - 1;
+ROLLBACK TO SAVEPOINT first_savepoint;
+UPDATE animals SET weight_kg = weight_kg * - 1 WHERE weight_kg < 0;
+COMMIT TRANSACTION;

--- a/queries.sql
+++ b/queries.sql
@@ -9,10 +9,13 @@ SELECT * FROM animals WHERE neutered = true;
 SELECT * FROM animals WHERE name <> 'Gabumon';
 SELECT * FROM animals WHERE weight_kg BETWEEN 10.4 AND 17.3;
 
-/*Inside a transaction update the animals table by setting the species column to unspecified. 
-Verify that change was made. Then roll back the change and verify that the species columns went 
-back to the state before the transaction.*/
-
+/* Setting species column and rolling back */
 BEGIN TRANSACTION;
 UPDATE animals SET species = 'unspecified';
 ROLLBACK TRANSACTION;
+
+/* Setting species colum and persisting the change */
+BEGIN TRANSACTION;
+UPDATE animals SET species = 'digimon' WHERE name LIKE '%mon';
+UPDATE animals SET species = 'pokemon' WHERE species = '';
+COMMIT TRANSACTION;

--- a/queries.sql
+++ b/queries.sql
@@ -8,3 +8,11 @@ SELECT name, escape_attempts FROM animals WHERE weight_kg > 10.5;
 SELECT * FROM animals WHERE neutered = true;
 SELECT * FROM animals WHERE name <> 'Gabumon';
 SELECT * FROM animals WHERE weight_kg BETWEEN 10.4 AND 17.3;
+
+/*Inside a transaction update the animals table by setting the species column to unspecified. 
+Verify that change was made. Then roll back the change and verify that the species columns went 
+back to the state before the transaction.*/
+
+BEGIN TRANSACTION;
+UPDATE animals SET species = 'unspecified';
+ROLLBACK TRANSACTION;

--- a/queries.sql
+++ b/queries.sql
@@ -33,3 +33,11 @@ UPDATE animals SET weight_kg = weight_kg * - 1;
 ROLLBACK TO SAVEPOINT first_savepoint;
 UPDATE animals SET weight_kg = weight_kg * - 1 WHERE weight_kg < 0;
 COMMIT TRANSACTION;
+
+/* Queries to get some statistics */
+SELECT COUNT(*) FROM animals;
+SELECT COUNT(*) FROM animals WHERE escape_attempts = 0;
+SELECT AVG(weight_kg) FROM animals;
+SELECT * FROM animals WHERE escape_attempts = ( SELECT MAX(escape_attempts) FROM animals );
+SELECT species, MAX(weight_kg), MIN(weight_kg) FROM animals GROUP BY species;
+SELECT species, AVG(escape_attempts) FROM animals WHERE EXTRACT(YEAR FROM date_of_birth) BETWEEN 1990 AND 2000  GROUP BY species;

--- a/schema.sql
+++ b/schema.sql
@@ -8,3 +8,5 @@ CREATE TABLE IF NOT EXISTS animals (
    neutered bool,
    weight_kg float(3)
 );
+
+ALTER TABLE animals ADD species VARCHAR ( 100 );

--- a/schema.sql
+++ b/schema.sql
@@ -9,4 +9,5 @@ CREATE TABLE IF NOT EXISTS animals (
    weight_kg float(3)
 );
 
+/* Add species column */
 ALTER TABLE animals ADD species VARCHAR ( 100 );


### PR DESCRIPTION
### This PR contains the following queries on `animals` table to: 
- add species column
- populate the table
- update the table by setting `species` to `unspecified` and then rolling back the change in a transaction
- update `species` to `digimon` and `pokemon` depending on the name of the animal in a transaction
![set_species](https://user-images.githubusercontent.com/23447217/229174726-2e81c36d-7d31-454b-b603-059be9379334.png)
- delete all records in table and roll back in a transaction
![delete_records_rollback](https://user-images.githubusercontent.com/23447217/229175309-fb642a5e-7d1e-4db9-bb7b-2981d1aad619.png)
- delete all animals born after Jan 1st, 2022 and update animals' weight 
![update_weight](https://user-images.githubusercontent.com/23447217/229175680-f110979d-5b00-40df-9f02-74420192e291.png)
- number of all animals 
- number of animals who have never tried to escape
- average weight of animals 
- the animal who escaped the most 
- the min and max weight of each type of animal and the average number of escape attempts per animal type of those born between 1990 and 2000
![statistics](https://user-images.githubusercontent.com/23447217/229176572-ff27a282-4acd-41cd-84e7-6deb1b599125.png)
 